### PR TITLE
Added support for matrices have NA value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: parallelDist
 Type: Package
 Title: Parallel Distance Matrix Computation using Multiple Threads
-Version: 0.2.6
+Version: 0.2.6.1
 Author: Alexander Eckert [aut, cre], Lucas Godoy [ctb], Srikanth KS [ctb]
 Authors@R: c(
     person("Alexander", "Eckert", role = c("aut", "cre"), email = "info@alexandereckert.com"),
     person("Lucas", "Godoy", role = "ctb", email = "lucasdac.godoy@gmail.com"),
-    person("Srikanth", "KS", role = "ctb", email = "sri.teach@gmail.com")
+    person("Srikanth", "KS", role = "ctb", email = "sri.teach@gmail.com"),
+    person("Jiawei", "Lian", role="ctb", email = "1049861267@qq.com")
     )
 Maintainer: Alexander Eckert <info@alexandereckert.com>
 Description: A fast parallelized alternative to R's native 'dist' function to

--- a/src/DistanceDist.h
+++ b/src/DistanceDist.h
@@ -102,13 +102,10 @@ class DistanceDivergence : public IDistance {
 class DistanceEuclidean : public IDistance {
   public:
     double calcDistance(const arma::mat &A, const arma::mat &B) {
-        checkNanPairs(A, B);
-
         arma::mat tmp = A - B;
         if (tmp.has_nan()) {
           remove_nan(tmp);
           res = std::sqrt(arma::accu(arma::square(tmp)) / proportion());
-          std::cout << "res = " << res << "; countFinite = " << countFinite << "; countCol = " << countCol << "; nanPairs = " << nanPairs << "; proportion = " << proportion() << std::endl;
         } else {
           res = std::sqrt(arma::accu(arma::square(tmp)));
         }

--- a/src/DistanceDist.h
+++ b/src/DistanceDist.h
@@ -21,6 +21,7 @@
 #define DISTANCEDIST_H_
 
 #include <limits>
+#include <iostream>
 
 #include "IDistance.h"
 #include "Util.h"
@@ -53,8 +54,8 @@ class DistanceBray : public IDistance {
 class DistanceCanberra : public IDistance {
   public:
     double calcDistance(const arma::mat &A, const arma::mat &B) {
-        arma::mat denominator = arma::abs(A) + arma::abs(B);
-        arma::mat ratio = arma::abs(A) - arma::abs(B) / denominator;
+        arma::mat denominator = arma::abs(A + B);
+        arma::mat ratio = (arma::abs(A - B)) / denominator;
 
         if (ratio.has_nan()) {
           remove_nan(ratio);
@@ -101,10 +102,13 @@ class DistanceDivergence : public IDistance {
 class DistanceEuclidean : public IDistance {
   public:
     double calcDistance(const arma::mat &A, const arma::mat &B) {
+        checkNanPairs(A, B);
+
         arma::mat tmp = A - B;
         if (tmp.has_nan()) {
           remove_nan(tmp);
-          res = std::sqrt(arma::accu(arma::square(tmp))) / proportion();
+          res = std::sqrt(arma::accu(arma::square(tmp)) / proportion());
+          std::cout << "res = " << res << "; countFinite = " << countFinite << "; countCol = " << countCol << "; nanPairs = " << nanPairs << "; proportion = " << proportion() << std::endl;
         } else {
           res = std::sqrt(arma::accu(arma::square(tmp)));
         }

--- a/src/IDistance.h
+++ b/src/IDistance.h
@@ -51,19 +51,6 @@ class IDistance {
     virtual ~IDistance() {}
     virtual double calcDistance(const mat &A, const mat &B) = 0;
 
-  protected:
-    double res;
-    int countFinite;
-    int countCol;
-
-    double proportion() { return (double)countFinite/countCol; }
-    
-    void remove_nan(mat &res) {        
-        countFinite = arma::uvec(arma::find_finite( res )).n_elem;
-        countCol = res.n_cols;
-        res.elem( find_nonfinite(res) ).zeros();
-    }
-
 };
 
 #endif // IDISTANCE_H_

--- a/src/IDistance.h
+++ b/src/IDistance.h
@@ -55,20 +55,12 @@ class IDistance {
     double res;
     int countFinite;
     int countCol;
-    int nanPairs = 0;
-
-    void checkNanPairs(const mat &A, const mat &B) {
-        arma::uvec A_na = find_nonfinite(A);
-        arma::uvec B_na = find_nonfinite(B);
-        arma::uvec commonIdx = intersect(A_na, B_na);
-        nanPairs = commonIdx.n_rows;
-    }
 
     double proportion() { return (double)countFinite/countCol; }
     
     void remove_nan(mat &res) {        
         countFinite = arma::uvec(arma::find_finite( res )).n_elem;
-        countCol = res.n_cols - nanPairs;
+        countCol = res.n_cols;
         res.elem( find_nonfinite(res) ).zeros();
     }
 

--- a/src/IDistance.h
+++ b/src/IDistance.h
@@ -55,12 +55,20 @@ class IDistance {
     double res;
     int countFinite;
     int countCol;
+    int nanPairs = 0;
+
+    void checkNanPairs(const mat &A, const mat &B) {
+        arma::uvec A_na = find_nonfinite(A);
+        arma::uvec B_na = find_nonfinite(B);
+        arma::uvec commonIdx = intersect(A_na, B_na);
+        nanPairs = commonIdx.n_rows;
+    }
 
     double proportion() { return (double)countFinite/countCol; }
     
     void remove_nan(mat &res) {        
         countFinite = arma::uvec(arma::find_finite( res )).n_elem;
-        countCol = res.n_cols;
+        countCol = res.n_cols - nanPairs;
         res.elem( find_nonfinite(res) ).zeros();
     }
 

--- a/src/IDistance.h
+++ b/src/IDistance.h
@@ -50,6 +50,20 @@ class IDistance {
   public:
     virtual ~IDistance() {}
     virtual double calcDistance(const mat &A, const mat &B) = 0;
+
+  protected:
+    double res;
+    int countFinite;
+    int countCol;
+
+    double proportion() { return (double)countFinite/countCol; }
+    
+    void remove_nan(mat &res) {        
+        countFinite = arma::uvec(arma::find_finite( res )).n_elem;
+        countCol = res.n_cols;
+        res.elem( find_nonfinite(res) ).zeros();
+    }
+
 };
 
 #endif // IDISTANCE_H_

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -29,4 +29,11 @@ double similarityToDistance(const double distance) {
     return 1.0 - std::abs(distance);
 }
 
+void remove_nan(arma::mat &res, int &countFinite, int &countCol) {        
+    countFinite = arma::uvec(arma::find_finite( res )).n_elem;
+    countCol = res.n_cols;
+    res.elem( find_nonfinite(res) ).zeros();
+}
+
+
 } // namespace util

--- a/src/Util.h
+++ b/src/Util.h
@@ -23,12 +23,17 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <RcppArmadillo.h>
 
 namespace util {
 
 bool isEqualStr(const std::string &str1, std::string str2);
 
 double similarityToDistance(const double distance);
+
+inline double proportion(const int countFinite, const int countCol) { return (double)countFinite/countCol; }
+
+void remove_nan(arma::mat &res, int &countFinite, int &countCol);
 
 } // namespace util
 

--- a/tests/testthat/testMatrixNA.R
+++ b/tests/testthat/testMatrixNA.R
@@ -1,31 +1,16 @@
-## testMatrixDistances.R
-##
-## Copyright (C)  2017, 2021  Alexander Eckert
-##
-## This file is part of parallelDist.
-##
-## parallelDist is free software: you can redistribute it and/or modify it
-## under the terms of the GNU General Public License as published by
-## the Free Software Foundation, either version 2 of the License, or
-## (at your option) any later version.
-##
-## parallelDist is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with parallelDist. If not, see <http://www.gnu.org/licenses/>.
-
 context("Distance methods using matrix as input")
 
-mat.sample1 <- matrix(c(0, 1, 0, 1, 0, 0, 1, 0), nrow = 2)
-mat.sample2 <- matrix(c(0, 1, 0, 1, 0, 0, 1, 0, 1, 1), nrow = 2)
+set.seed(1)
+mat.sample1 <- matrix(c(NA, 2, NA, 4, NA, 6, 7, 8 ,9, NA, 11, 12), nrow = 4)
+mat.sample2 <- matrix(c(0, 1, 0, 1, NA, 0, 1, 0, 1, 1), nrow = 2)
 mat.sample3 <- matrix(c(1:500), ncol = 5)
+p <- 0.3
+mat.sample3 <- apply(mat.sample3, 1:2, function(x) sample(c(x, NA), 1, prob=c((1 - p), p)))
 mat.sample4 <- matrix(rep(0, 100), ncol = 5)
 mat.sample5 <- matrix(c(-500:499), ncol = 5)
-mat.sample6 <- matrix(c(1:2), ncol = 1)
-mat.sample7 <- matrix(c(0.5, 1, 0, 1, 0, 0, 1, 0.3, 1, 1), nrow = 2)
+p <- 0.2
+mat.sample5 <- apply(mat.sample5, 1:2, function(x) sample(c(x, NA), 1, prob=c((1 - p), p)))
+mat.sample6 <- matrix(c(1:NA), ncol = 1)
 
 
 mat.list <- list(mat.sample1, mat.sample2, mat.sample3, mat.sample4, mat.sample5, mat.sample6, mat.sample7)
@@ -57,10 +42,10 @@ test_that("dist class label attribute keeps preserved", {
   namedMatrix <- matrix(1:12, 4)
   colnames(namedMatrix) <- c("A", "B", "C")
   rownames(namedMatrix) <- c("a", "b", "c", "d")
-
+  
   attributes1 <- attributes(parDist(namedMatrix))
   attributes2 <- attributes(dist(namedMatrix))
-
+  
   expect_equal(attributes1$Labels, attributes2$Labels)
 })
 

--- a/tests/testthat/testMatrixNA.R
+++ b/tests/testthat/testMatrixNA.R
@@ -7,11 +7,13 @@ mat.sample3 <- matrix(c(1:500), ncol = 5)
 p <- 0.3
 mat.sample3 <- apply(mat.sample3, 1:2, function(x) sample(c(x, NA), 1, prob=c((1 - p), p)))
 mat.sample4 <- matrix(rep(0, 100), ncol = 5)
+p <- 0.4
+mat.sample4 <- apply(mat.sample4, 1:2, function(x) sample(c(x, NA), 1, prob=c((1 - p), p)))
 mat.sample5 <- matrix(c(-500:499), ncol = 5)
 p <- 0.2
 mat.sample5 <- apply(mat.sample5, 1:2, function(x) sample(c(x, NA), 1, prob=c((1 - p), p)))
-mat.sample6 <- matrix(c(1:NA), ncol = 1)
-
+mat.sample6 <- matrix(c(1, NA), ncol = 1)
+mat.sample7 <- matrix(NA, ncol = 1)
 
 mat.list <- list(mat.sample1, mat.sample2, mat.sample3, mat.sample4, mat.sample5, mat.sample6, mat.sample7)
 
@@ -42,67 +44,21 @@ test_that("dist class label attribute keeps preserved", {
   namedMatrix <- matrix(1:12, 4)
   colnames(namedMatrix) <- c("A", "B", "C")
   rownames(namedMatrix) <- c("a", "b", "c", "d")
-  
+
   attributes1 <- attributes(parDist(namedMatrix))
   attributes2 <- attributes(dist(namedMatrix))
-  
+
   expect_equal(attributes1$Labels, attributes2$Labels)
-})
-
-test_that("bhjattacharyya method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "bhjattacharyya")
-})
-
-test_that("bray method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "bray")
 })
 
 test_that("canberra method produces same outputs as dist", {
   testMatrixListEquality(mat.list, "canberra")
 })
 
-test_that("chord method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "chord")
-})
-
-test_that("divergence method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "divergence")
-})
-
 test_that("euclidean method produces same outputs as dist", {
   testMatrixListEquality(mat.list, "euclidean")
 })
-# (only vals [0,1])
-test_that("fJaccard method produces same outputs as dist", {
-  testMatrixListEquality(list(mat.sample1, mat.sample2, mat.sample7), "fJaccard")
-})
 
-test_that("geodesic method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "geodesic")
-})
-
-test_that("hellinger method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "hellinger")
-})
-
-test_that("kullback method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "kullback")
-})
-
-test_that("mahalanobis method produces same outputs as dist", {
-  mat.mahalanobis <- cbind(1:6, 1:3)
-  testMatrixEquality(mat.mahalanobis, "mahalanobis")
-  testMatrixEquality(mat.mahalanobis, "mahalanobis", cov = cov(mat.mahalanobis))
-  expect_equal(
-    as.matrix(parDist(mat.mahalanobis, "mahalanobis", cov = solve(cov(mat.mahalanobis)), inverted = TRUE)),
-    as.matrix(dist(mat.mahalanobis, method = "mahalanobis", cov = cov(mat.mahalanobis)))
-  )
-})
-test_that("mahalanobis method throws error for list of matrices input", {
-  mat.mahalanobis <- cbind(1:6, 1:3)
-  mat.list <- list(mat.mahalanobis, mat.mahalanobis)
-  expect_error(parDist(mat.list, "mahalanobis"), "Calculation of inverted covariance matrix is only supported for input data in matrix format.")
-})
 
 test_that("manhattan method produces same outputs as dist", {
   testMatrixListEquality(mat.list, "manhattan")
@@ -118,137 +74,4 @@ test_that("minkowski method produces same outputs as dist", {
   }
 })
 
-test_that("podani method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "podani")
-})
-# possible wrong implementation in proxy?
-test_that("soergel method produces expected output", {
-  expect_equal(as.matrix(parDist(mat.sample1, method = "soergel"))[1, 2], 1)
-  expect_equal(as.matrix(parDist(mat.sample2, method = "soergel"))[1, 2], 0.75)
-  expect_equal(as.matrix(parDist(mat.sample3, method = "soergel"))[1, 2], 0.0049504950495049506)
-  expect_equal(as.matrix(parDist(mat.sample4, method = "soergel"))[1, 2], NaN)
-  expect_equal(as.matrix(parDist(mat.sample5, method = "soergel"))[1, 2], -0.010101010101010102)
-  expect_equal(as.matrix(parDist(mat.sample6, method = "soergel"))[1, 2], 0.5)
-  expect_equal(as.matrix(parDist(mat.sample7, method = "soergel"))[1, 2], 0.55)
-})
-# wrong implementation in proxy?
-test_that("wave method produces same outputs as dist", {
-  expect_equal(as.matrix(parDist(mat.sample1, method = "wave"))[1, 2], NaN)
-  expect_equal(as.matrix(parDist(mat.sample2, method = "wave"))[1, 2], NaN)
-  expect_equal(as.matrix(parDist(mat.sample3, method = "wave"))[1, 2], 0.5205532370853329)
-  expect_equal(as.matrix(parDist(mat.sample4, method = "wave"))[1, 2], NaN)
-  expect_equal(as.matrix(parDist(mat.sample5, method = "wave"))[1, 2], -0.0022262504871707334)
-  expect_equal(as.matrix(parDist(mat.sample6, method = "wave"))[1, 2], 0.5)
-  expect_equal(as.matrix(parDist(mat.sample7, method = "wave"))[1, 2], NaN)
-})
 
-test_that("whittaker method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "whittaker")
-})
-# binary distances
-
-test_that("binary method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "binary")
-})
-
-test_that("braunblanquet method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "braun-blanquet")
-})
-
-test_that("dice method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "dice")
-})
-
-test_that("fager method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "fager")
-})
-
-test_that("faith method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "faith")
-})
-
-test_that("hamman method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "hamman")
-})
-
-test_that("kulczynski1 method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "kulczynski1")
-})
-
-test_that("kulczynski2 method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "kulczynski2")
-})
-
-test_that("michael method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "michael")
-})
-
-test_that("mountford method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "mountford")
-})
-
-test_that("mozley method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "mozley")
-})
-
-test_that("ochiai method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "ochiai")
-})
-
-test_that("phi method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "phi")
-})
-
-test_that("russel method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "russel")
-})
-
-test_that("simplematching method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "simple matching")
-})
-
-test_that("simpson method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "simpson")
-})
-
-test_that("stiles method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "stiles")
-})
-
-test_that("tanimoto method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "tanimoto")
-})
-
-test_that("yule method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "yule")
-})
-
-test_that("yule2 method produces same outputs as dist", {
-  testMatrixListEquality(mat.list, "yule2")
-})
-
-test_that("cosine method produces same outputs as dist", {
-  testMatrixListEquality(mat.list[-4], "cosine") # dividing by zero
-})
-
-# test for hamming distance method
-hammingR <- function(x, y) {
-  sum(x != y) / length(x)
-}
-
-testMatrixEqualityHamming <- function(matrix, ...) {
-  testthat::expect_equal(
-    as.matrix(parDist(matrix, method = "hamming", ...)),
-    as.matrix(proxy::dist(matrix, method = hammingR, ...))
-  )
-}
-
-testMatrixListEqualityHamming <- function(matlist, ...) {
-  invisible(sapply(matlist, function(x) {
-    testMatrixEqualityHamming(x, ...)
-  }))
-}
-
-testthat::test_that("hamming method produces same outputs as dist", {
-  testMatrixListEqualityHamming(mat.list)
-})


### PR DESCRIPTION
Hi Alex,

Thanks for your job! I have added support for matrices have NA value. Please review and let me know if this adds value.

## What?
- Added support for matrices have NA value. Methods include: euclidean, maximum, manhattan, Canberra, and Minkowski.
- Revised the computational formula of Canberra a little, based on dist source code.

## Why?
- These changes support the calculation of matrices with NA value, since original dist() supports.
- The original computational formula of Canberra in parDist() gives different results than dist() when there is more than one NA value in one row. The changes in the computational formula of Canberra correct the results.

## How?
- Added function proportion() to normalize the results, and function remove_nan() to remove the NA values in matrices.
- Revised the calDistance(). The revised calDistance() first removes the NA values in a calculated vector (e.g., A - B) using remove_nan(). Then come up with an intermediate result. Finally, normalize the result and get the final result using proportion().

## Testing?
The code has passed the original test cases. I also add a new unit test file (testMatrixNA.R) to test the cases when matrices have NA values.

Best regards,
Jiawei