### PR TITLE
Remove obsolete CXX_STD = CXX11 to allow Armadillo 15.0.x migration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Imports:
 LinkingTo: Rcpp,
     RcppParallel,
     RcppArmadillo
-SystemRequirements: C++11
 Suggests:
     dtw,
     ggplot2,

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,1 @@
-CXX_STD = CXX11
-
 PKG_LIBS = `${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,3 @@
-CXX_STD = CXX11
-
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
 
 PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard. For most packages, adapting to it can be very simple, and yours is one of them. In this PR we simply remove the declaration from the reference version of Makevars and Makevars.win as well as from DESCRIPTION -- and no other changes are needed.

Please see issues #475 and below for context, and notably #489 for this first wave of PRs. It would be terrific if you could make an upload to CRAN 'soon' to remove the reliance on C++11 which we needed in the past, but which is by now a hindrance. Please do not hesitate to reach out if I can assist in any way or clarify matters.

/cc @kurthornik